### PR TITLE
Trivial Bugfix: not printing deepspeed version if deepspeed has not been imported

### DIFF
--- a/RWKV-v4neo/train.py
+++ b/RWKV-v4neo/train.py
@@ -237,7 +237,7 @@ if __name__ == "__main__":
 # Adam = lr {args.lr_init} to {args.lr_final}, warmup {args.warmup_steps} steps, beta {args.betas}, eps {args.adam_eps}
 #
 # Found torch {torch.__version__}, recommend 1.13.1+cu117 or newer
-# Found deepspeed {deepspeed.__version__ if importlib.util.find_spec('deepspeed') else 'None'}, recommend 0.7.0 (faster than newer versions)
+# Found deepspeed {deepspeed.__version__ if 'deepspeed' in sys.modules else 'None'}, recommend 0.7.0 (faster than newer versions)
 # Found pytorch_lightning {pl.__version__}, recommend 1.9.1 or newer
 #
 ############################################################################


### PR DESCRIPTION
Hello,

Thank you very much for your contributions.

The check is currently looking for whether the module is installed or not, rather than imported. This makes it impossible to execute non-deepspeed strategies when deepspeed is installed in the environment.

~PV