### PR TITLE
Fix message error when using numpy type data

### DIFF
--- a/RWKV-v4neo/src/dataset.py
+++ b/RWKV-v4neo/src/dataset.py
@@ -57,13 +57,13 @@ class MyDataset(Dataset):
         elif args.data_type == "numpy":
             self.data = np.load(args.data_file).astype("int")
             self.vocab_size = args.vocab_size
-            rank_zero_info("Current vocab size =", self.vocab_size, "(make sure it's correct)")
+            rank_zero_info(f"Current vocab size = {self.vocab_size} (make sure it's correct)")
             self.data_size = len(self.data)
             rank_zero_info(f"Data has {self.data_size} tokens.")
         elif args.data_type == "uint16":
             self.data = np.fromfile(args.data_file, dtype=np.uint16).astype("int32").reshape(-1, args.my_sample_len)
             self.vocab_size = args.vocab_size
-            rank_zero_info("Current vocab size =", self.vocab_size, "(make sure it's correct)")
+            rrank_zero_info(f"Current vocab size = {self.vocab_size} (make sure it's correct)")
             self.data_size = self.data.shape[0]
             rank_zero_info(f"Data has {self.data_size} samples.")
         elif args.data_type == "wds_img":


### PR DESCRIPTION
Fix below issue:
--- Logging error ---
Traceback (most recent call last):
  File "/usr/local/miniconda3/envs/zxy/lib/python3.8/logging/__init__.py", line 1085, in emit
    msg = self.format(record)
  File "/usr/local/miniconda3/envs/zxy/lib/python3.8/logging/__init__.py", line 929, in format
    return fmt.format(record)
  File "/usr/local/miniconda3/envs/zxy/lib/python3.8/logging/__init__.py", line 668, in format
    record.message = record.getMessage()
  File "/usr/local/miniconda3/envs/zxy/lib/python3.8/logging/__init__.py", line 373, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
Call stack:
  File "train.py", line 288, in <module>
    train_data = MyDataset(args)
  File "/root/zhuangxy/RWKV-LM/RWKV-v4neo/src/dataset.py", line 60, in __init__
    rank_zero_info("Current vocab size =", self.vocab_size, "(make sure it's correct)")
  File "/usr/local/miniconda3/envs/zxy/lib/python3.8/site-packages/lightning_utilities/core/rank_zero.py", line 27, in wrapped_fn
    return fn(*args, **kwargs)
  File "/usr/local/miniconda3/envs/zxy/lib/python3.8/site-packages/lightning_utilities/core/rank_zero.py", line 54, in rank_zero_info
    _info(*args, stacklevel=stacklevel, **kwargs)
  File "/usr/local/miniconda3/envs/zxy/lib/python3.8/site-packages/lightning_utilities/core/rank_zero.py", line 48, in _info
    log.info(*args, **kwargs)
Message: 'Current vocab size ='
Arguments: (50277, "(make sure it's correct)")
Data has 30220625 tokens.