### PR TITLE
Fix missing return in __getitem__ for uint16 in dataset.py

### DIFF
--- a/RWKV-v5/src/dataset.py
+++ b/RWKV-v5/src/dataset.py
@@ -111,6 +111,7 @@ class MyDataset(Dataset):
             dix = self.data[i]
             x = torch.tensor(dix[:-1], dtype=torch.long)
             y = torch.tensor(dix[1:], dtype=torch.long)
+            return x, y
         else:
             ctx_len = args.ctx_len
             req_len = ctx_len + 1


### PR DESCRIPTION
The __getitem__ method did not return any value when args.data_type == "uint16", causing data loaders to receive None. Added an explicit `return x, y` to match the behavior of other data types.